### PR TITLE
Fix zipcode handling

### DIFF
--- a/src/pvo/models.py
+++ b/src/pvo/models.py
@@ -88,7 +88,7 @@ class System(BaseModel):
     status_interval: Optional[int]
     system_name: str
     system_size: Optional[int]
-    zipcode: Optional[int]
+    zipcode: Optional[str]
 
     @validator("install_date", pre=True)
     @classmethod

--- a/src/pvo/models.py
+++ b/src/pvo/models.py
@@ -52,9 +52,7 @@ class Status(BaseModel):
         Returns:
             Filtered value.
         """
-        if value == "NaN":
-            return None
-        return value
+        return None if value == "NaN" else value
 
     @validator("reported_date", pre=True)
     @classmethod

--- a/tests/test_pvoutput.py
+++ b/tests/test_pvoutput.py
@@ -165,7 +165,7 @@ async def test_get_system(aresponses):
             status=200,
             headers={"Content-Type": "text/plain"},
             text=(
-                "Frenck,5015,1234,17,295,JA solar JAM-300,1,5000,"
+                "Frenck,5015,CO1,17,295,JA solar JAM-300,1,5000,"
                 "SolarEdge SE5000H,S,20.0,Low,20180622,51.1234,6.1234,5;;0"
             ),
         ),
@@ -190,4 +190,4 @@ async def test_get_system(aresponses):
     assert system.status_interval == 5
     assert system.system_name == "Frenck"
     assert system.system_size == 5015
-    assert system.zipcode == 1234
+    assert system.zipcode == CO1

--- a/tests/test_pvoutput.py
+++ b/tests/test_pvoutput.py
@@ -190,4 +190,4 @@ async def test_get_system(aresponses):
     assert system.status_interval == 5
     assert system.system_name == "Frenck"
     assert system.system_size == 5015
-    assert system.zipcode == CO1
+    assert system.zipcode == "CO1"


### PR DESCRIPTION
# Proposed Changes

Changed the `zipcode` type to `str` instead of `int` as some postcodes like in UK are non-numeric. 

This was throwing an error in HA log trying to parse the value.

## Related Issues

None

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
