### PR TITLE
Detect missing status data

### DIFF
--- a/src/pvo/__init__.py
+++ b/src/pvo/__init__.py
@@ -1,10 +1,11 @@
 """Asynchronous client for the PVOutput API."""
 from .models import Status, System
-from .pvoutput import (
-    PVOutput,
+from .pvoutput import PVOutput
+from .exceptions import (
     PVOutputAuthenticationError,
     PVOutputConnectionError,
     PVOutputError,
+    PVOutputNoDataError,
 )
 
 __all__ = [
@@ -12,6 +13,7 @@ __all__ = [
     "PVOutputAuthenticationError",
     "PVOutputConnectionError",
     "PVOutputError",
+    "PVOutputNoDataError",
     "Status",
     "System",
 ]

--- a/src/pvo/exceptions.py
+++ b/src/pvo/exceptions.py
@@ -13,5 +13,9 @@ class PVOutputConnectionError(PVOutputError):
     """PVOutput connection exception."""
 
 
+class PVOutputNoDataError(PVOutputError):
+    """PVOutput has no data available exception."""
+
+
 class InvalidSystemIDError(PVOutputError):
     """Invalid system ID exception."""

--- a/src/pvo/pvoutput.py
+++ b/src/pvo/pvoutput.py
@@ -15,6 +15,7 @@ from .exceptions import (
     PVOutputAuthenticationError,
     PVOutputConnectionError,
     PVOutputError,
+    PVOutputNoDataError,
 )
 from .models import Status, System
 
@@ -86,6 +87,10 @@ class PVOutput:
                 "Timeout occurred while connecting to the PVOutput API"
             ) from exception
         except ClientResponseError as exception:
+            if exception.status == 400 and uri.startswith("getstatus.jsp"):
+                raise PVOutputNoDataError(
+                    "PVOutput has no status data available for this system"
+                ) from exception
             if exception.status in [401, 403]:
                 raise PVOutputAuthenticationError(
                     "Authentication to the PVOutput API failed"

--- a/tests/test_pvoutput.py
+++ b/tests/test_pvoutput.py
@@ -11,6 +11,7 @@ from pvo.exceptions import (
     PVOutputAuthenticationError,
     PVOutputConnectionError,
     PVOutputError,
+    PVOutputNoDataError,
 )
 
 
@@ -152,6 +153,22 @@ async def test_get_status(aresponses):
     assert status.power_generation == 0
     assert status.temperature == 21.2
     assert status.voltage == 220.1
+
+
+@pytest.mark.asyncio
+async def test_get_status_no_data(aresponses):
+    """Test PVOutput status without data is handled."""
+    aresponses.add(
+        "pvoutput.org",
+        "/service/r2/getstatus.jsp",
+        "GET",
+        aresponses.Response(text="Bad Request!", status=400),
+    )
+
+    async with aiohttp.ClientSession() as session:
+        pvoutput = PVOutput(api_key="fake", system_id=12345, session=session)
+        with pytest.raises(PVOutputNoDataError):
+            await pvoutput.status()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Proposed Changes

If there is no status data available for today, PVOutput will just go and throw up a HTTP 400 😢 
This ain't pretty, but we'll have to deal with it in some way.

## Related Issues

https://github.com/home-assistant/core/issues/65046
