### PR TITLE
Add add_status method for uploading live data to PVOutput

### DIFF
--- a/src/pvo/pvoutput.py
+++ b/src/pvo/pvoutput.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 import asyncio
 import socket
 from dataclasses import dataclass
+from datetime import UTC, date, datetime, time
 from typing import Any, Self
 
 from aiohttp.client import ClientError, ClientResponseError, ClientSession
-from aiohttp.hdrs import METH_GET
+from aiohttp.hdrs import METH_GET, METH_POST
 from yarl import URL
 
 from .exceptions import (
@@ -166,6 +167,62 @@ class PVOutput:
                 )
             ),
         )
+
+    # pylint: disable-next=too-many-arguments
+    async def add_status(  # noqa: PLR0913
+        self,
+        *,
+        energy_generation: int | None = None,
+        power_generation: int | None = None,
+        energy_consumption: int | None = None,
+        power_consumption: int | None = None,
+        temperature: float | None = None,
+        voltage: float | None = None,
+        cumulative: bool = False,
+        net: bool = False,
+        reported_date: date | None = None,
+        reported_time: time | None = None,
+    ) -> None:
+        """Upload a live status update to PVOutput.
+
+        Args:
+        ----
+            energy_generation: Energy generation in watt hours (Wh).
+            power_generation: Power generation in watts (W).
+            energy_consumption: Energy consumption in watt hours (Wh).
+            power_consumption: Power consumption in watts (W).
+            temperature: Temperature in celsius (C).
+            voltage: Voltage in volts (V).
+            cumulative: Whether energy values are lifetime cumulative.
+            net: Whether values are net import/export.
+            reported_date: Date of the status. Defaults to today.
+            reported_time: Time of the status. Defaults to now.
+
+        """
+        now = datetime.now(tz=UTC)
+        data: dict[str, str] = {
+            "d": (reported_date or now.date()).strftime("%Y%m%d"),
+            "t": (reported_time or now.time()).strftime("%H:%M"),
+        }
+
+        if energy_generation is not None:
+            data["v1"] = str(energy_generation)
+        if power_generation is not None:
+            data["v2"] = str(power_generation)
+        if energy_consumption is not None:
+            data["v3"] = str(energy_consumption)
+        if power_consumption is not None:
+            data["v4"] = str(power_consumption)
+        if temperature is not None:
+            data["v5"] = str(temperature)
+        if voltage is not None:
+            data["v6"] = str(voltage)
+        if cumulative:
+            data["c1"] = "1"
+        if net:
+            data["n"] = "1"
+
+        await self._request("addstatus.jsp", method=METH_POST, data=data)
 
     async def close(self) -> None:
         """Close open client session."""

--- a/tests/test_pvoutput.py
+++ b/tests/test_pvoutput.py
@@ -9,6 +9,7 @@ import aiohttp
 import pytest
 from aioresponses import aioresponses
 from syrupy.assertion import SnapshotAssertion
+from yarl import URL
 
 from pvo import PVOutput
 from pvo.exceptions import (
@@ -214,6 +215,96 @@ async def test_get_system(snapshot: SnapshotAssertion) -> None:
     assert system.zipcode == "CO1"
 
     assert system.to_dict() == snapshot
+
+
+async def test_add_status() -> None:
+    """Test adding a status update."""
+    with aioresponses() as mocked:
+        mocked.post(
+            "https://pvoutput.org/service/r2/addstatus.jsp",
+            status=200,
+            body="OK 200: Added Status",
+            content_type="text/plain",
+        )
+        async with aiohttp.ClientSession() as session:
+            pvoutput = PVOutput(api_key="fake", system_id=12345, session=session)
+            await pvoutput.add_status(
+                reported_date=date(2021, 12, 22),
+                reported_time=time(14, 30),
+                energy_generation=3636,
+                power_generation=500,
+                energy_consumption=1200,
+                power_consumption=350,
+                temperature=21.2,
+                voltage=220.1,
+            )
+
+        assert mocked.requests is not None
+        data = mocked.requests[
+            ("POST", URL("https://pvoutput.org/service/r2/addstatus.jsp"))
+        ][0].kwargs["data"]
+        assert data["d"] == "20211222"
+        assert data["t"] == "14:30"
+        assert data["v1"] == "3636"
+        assert data["v2"] == "500"
+        assert data["v3"] == "1200"
+        assert data["v4"] == "350"
+        assert data["v5"] == "21.2"
+        assert data["v6"] == "220.1"
+        assert "c1" not in data
+        assert "n" not in data
+
+
+async def test_add_status_with_flags() -> None:
+    """Test adding a status update with cumulative and net flags."""
+    with aioresponses() as mocked:
+        mocked.post(
+            "https://pvoutput.org/service/r2/addstatus.jsp",
+            status=200,
+            body="OK 200: Added Status",
+            content_type="text/plain",
+        )
+        async with aiohttp.ClientSession() as session:
+            pvoutput = PVOutput(api_key="fake", system_id=12345, session=session)
+            await pvoutput.add_status(
+                reported_date=date(2021, 12, 22),
+                reported_time=time(14, 30),
+                energy_generation=50000,
+                energy_consumption=12000,
+                cumulative=True,
+                net=True,
+            )
+
+        assert mocked.requests is not None
+        data = mocked.requests[
+            ("POST", URL("https://pvoutput.org/service/r2/addstatus.jsp"))
+        ][0].kwargs["data"]
+        assert data["c1"] == "1"
+        assert data["n"] == "1"
+        assert data["v1"] == "50000"
+        assert data["v3"] == "12000"
+
+
+async def test_add_status_defaults_date_time() -> None:
+    """Test adding a status defaults to current date and time."""
+    with aioresponses() as mocked:
+        mocked.post(
+            "https://pvoutput.org/service/r2/addstatus.jsp",
+            status=200,
+            body="OK 200: Added Status",
+            content_type="text/plain",
+        )
+        async with aiohttp.ClientSession() as session:
+            pvoutput = PVOutput(api_key="fake", system_id=12345, session=session)
+            await pvoutput.add_status(power_generation=500)
+
+        assert mocked.requests is not None
+        data = mocked.requests[
+            ("POST", URL("https://pvoutput.org/service/r2/addstatus.jsp"))
+        ][0].kwargs["data"]
+        assert "d" in data
+        assert "t" in data
+        assert data["v2"] == "500"
 
 
 async def test_get_system_empty_install_date() -> None:


### PR DESCRIPTION
# Proposed Changes

- Add `add_status()` method to upload live status data (power, energy, temperature, voltage) to PVOutput via `addstatus.jsp`
- Supports cumulative energy and net import/export flags
- Date and time default to current UTC when omitted

